### PR TITLE
:bug: change to proper react camelCase

### DIFF
--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -26,7 +26,7 @@ class PhundDocument extends Document {
             <img
               src="https://queue.simpleanalyticscdn.com/noscript.gif"
               alt=""
-              referrerpolicy="no-referrer-when-downgrade"
+              referrerPolicy="no-referrer-when-downgrade"
             />
           </noscript>
         </body>


### PR DESCRIPTION
`referrerPolicy` in `_document.jsx` was html `referrerpolicy`. This fixes that 🪲 . 